### PR TITLE
Add development environment setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,27 @@ python3 -m build
 twine upload --skip-existing dist/*
 ```
 
+### Setting up development environment
+
+For development we use [Conda](https://docs.conda.io/en/latest/). First create the virtual environment
+
+```
+conda create -n tmh
+```
+
+Activate it
+
+```
+conda activate tmh
+```
+
+Install dependencies
+
+```
+conda install pytorch==1.10.0 torchvision==0.11.1 torchaudio==0.10.0 -c pytorch
+conda env update --file local.yml --prune
+```
+
 ### Read the docs
 https://tmh-docs.readthedocs.io/en/latest/docs.html#getting-started
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Install dependencies
 
 ```
 pip install https://github.com/pyannote/pyannote-audio/archive/develop.zip
-pip install torch==1.10.0+cu113 torchvision==0.11.1+cu113 torchaudio==0.10.0+cu113 cudatoolkit==11.3 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+pip install torch==1.10.0+cu113 torchvision==0.11.1+cu113 torchaudio==0.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 conda env update --file local.yml --prune
 ```
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Install dependencies
 
 ```
 pip install https://github.com/pyannote/pyannote-audio/archive/develop.zip
-conda install pytorch==1.10.0 torchvision==0.11.1 torchaudio==0.10.0 -c pytorch
+pip install torch==1.10.0+cu113 torchvision==0.11.1+cu113 torchaudio==0.10.0+cu113 cudatoolkit==11.3 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 conda env update --file local.yml --prune
 ```
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ conda activate tmh
 Install dependencies
 
 ```
+pip install https://github.com/pyannote/pyannote-audio/archive/develop.zip
 conda install pytorch==1.10.0 torchvision==0.11.1 torchaudio==0.10.0 -c pytorch
 conda env update --file local.yml --prune
 ```


### PR DESCRIPTION
While setting up the development environment, I run into some issues because the current torch versions in the environment.yaml are not available from the default repositories it seems (when running it pip could not find the torch==1.10.0+cu113 version). A workaround is to download the specific torch* packages before installing all dependencies in environment.yaml